### PR TITLE
Depends of symfony/panther:*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.0",
         "symfony/browser-kit": "^3.3|^4.0",
         "symfony/css-selector": "^3.3|^4.0",
-        "symfony/panther": "^0.1",
+        "symfony/panther": "*",
         "symfony/phpunit-bridge": "*"
     }
 }


### PR DESCRIPTION
Because Panther moves fast and is still in 0.x, it will allow users to automatically update to `0.2`, `0.3` and so on.