### PR TITLE
Don't restrict symfony/symfony packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "description": "A pack for functional and end-to-end testing within a Symfony app",
     "require": {
         "php": "^7.0",
-        "symfony/browser-kit": "^3.3|^4.0",
-        "symfony/css-selector": "^3.3|^4.0",
+        "symfony/browser-kit": "*",
+        "symfony/css-selector": "*",
         "symfony/panther": "*",
         "symfony/phpunit-bridge": "*"
     }


### PR DESCRIPTION
will allow "unpack" to replace the wildcard by what's in extra.symfony.require also (PR to come)