### PR TITLE
20210202 add dotenv dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "phpunit/phpunit": "*",
         "symfony/browser-kit": "*",
         "symfony/css-selector": "*",
-        "symfony/phpunit-bridge": "*"
+        "symfony/phpunit-bridge": "*",
+        "symfony/dotenv": "^v5.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "symfony/browser-kit": "*",
         "symfony/css-selector": "*",
         "symfony/phpunit-bridge": "*",
-        "symfony/dotenv": "^v5.1",
-
+        "symfony/dotenv": "^v5.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "symfony/browser-kit": "*",
         "symfony/css-selector": "*",
         "symfony/phpunit-bridge": "*",
-        "symfony/dotenv": "^v5.1"
+        "symfony/dotenv": "^v5.1",
+
     },
     "require-dev": {
         "phpunit/phpunit": "*",


### PR DESCRIPTION
Symfony v4.3 when installing test-pack does not update dotenv as a dependency of the package and in some cases, if dotenv is below version 5, there will be no bootEnv method that is in tests/bootstrap.php
