### PR TITLE
Restricting the test pack to 9.5 until symfony/phpunit-bridge supports 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "license": "MIT",
     "description": "A pack for functional and end-to-end testing within a Symfony app",
     "require": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "*",
         "symfony/css-selector": "*",
         "symfony/phpunit-bridge": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "*",
         "symfony/css-selector": "*",
         "symfony/phpunit-bridge": "*"


### PR DESCRIPTION
Currently, following the docs:

```
composer require --dev symfony/test-pack
php bin/phpunit
```

Fails because this is no longer the correct way to initialize PHPUnit 10: https://github.com/symfony/recipes/blob/b1176e36c42b0738c1475960202d7e074863ca3c/symfony/phpunit-bridge/5.3/bin/phpunit#L11

We could (and should, I think) fix that line to also support PHPUnit 10. But restricting the pack to 9 seems even better, as installing `phpunit/phpunit` 10 and running `vendor/bin/simple-phpunit` currently fails, and will fail until `symfony/phpunit-bridge` supports PHPUnit 10.