### PR TITLE
Remove symfony/phpunit-bridge from test-pack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,16 @@
     "license": "MIT",
     "description": "A pack for functional and end-to-end testing within a Symfony app",
     "require": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "*",
         "symfony/browser-kit": "*",
-        "symfony/css-selector": "*",
-        "symfony/phpunit-bridge": "*"
+        "symfony/css-selector": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "*",
         "symfony/browser-kit": "*",
-        "symfony/css-selector": "*",
-        "symfony/phpunit-bridge": "*"
+        "symfony/css-selector": "*"
+    },
+    "conflict": {
+        "phpunit/phpunit": "<11.1"
     }
 }


### PR DESCRIPTION
Fix #21

Reference: https://github.com/symfony/demo/pull/1549/files

I think the recommended way today should be work without the phpunit bridge and directly with phpunit.